### PR TITLE
Mute recording. Bubble up device reconnect event

### DIFF
--- a/android/src/main/java/expo/modules/audiostream/ExpoPlayAudioStreamModule.kt
+++ b/android/src/main/java/expo/modules/audiostream/ExpoPlayAudioStreamModule.kt
@@ -140,6 +140,10 @@ class ExpoPlayAudioStreamModule : Module(), EventSender {
             audioRecorderManager.stopRecording(promise)
         }
 
+        Function("toggleSilence") {
+            // not applicable for android
+        }
+
         AsyncFunction("setSoundConfig") { config: Map<String, Any?>, promise: Promise ->
             val useDefault = config["useDefault"] as? Boolean ?: false
             

--- a/ios/ExpoPlayAudioStreamModule.swift
+++ b/ios/ExpoPlayAudioStreamModule.swift
@@ -5,6 +5,7 @@ import ExpoModulesCore
 let audioDataEvent: String = "AudioData"
 let soundIsPlayedEvent: String = "SoundChunkPlayed"
 let soundIsStartedEvent: String = "SoundStarted"
+let deviceReconnectedEvent: String = "DeviceReconnected"
 
 
 public class ExpoPlayAudioStreamModule: Module, AudioStreamManagerDelegate, MicrophoneDataDelegate, SoundPlayerDelegate {
@@ -42,7 +43,7 @@ public class ExpoPlayAudioStreamModule: Module, AudioStreamManagerDelegate, Micr
         Name("ExpoPlayAudioStream")
         
         // Defines event names that the module can send to JavaScript.
-        Events([audioDataEvent, soundIsPlayedEvent, soundIsStartedEvent])
+        Events([audioDataEvent, soundIsPlayedEvent, soundIsStartedEvent, deviceReconnectedEvent])
         
         Function("destroy") {
             // Now we can properly reset all instances
@@ -299,6 +300,10 @@ public class ExpoPlayAudioStreamModule: Module, AudioStreamManagerDelegate, Micr
             microphone.stopRecording(resolver: promise)
         }
         
+        Function("toggleSilence") {
+            microphone.toggleSilence()
+        }
+        
         /// Sets the sound player configuration
         /// - Parameters:
         ///   - config: A dictionary containing configuration options:
@@ -492,6 +497,22 @@ public class ExpoPlayAudioStreamModule: Module, AudioStreamManagerDelegate, Micr
         ]
         // Emit the event to JavaScript
         sendEvent(audioDataEvent, eventBody)
+    }
+    
+    func onDeviceReconnected(_ reason: AVAudioSession.RouteChangeReason) {
+        let reasonString: String
+        switch reason {
+        case .newDeviceAvailable:
+            reasonString = "newDeviceAvailable"
+        case .oldDeviceUnavailable:
+            reasonString = "oldDeviceUnavailable"
+        case .unknown, .categoryChange, .override, .wakeFromSleep, .noSuitableRouteForCategory, .routeConfigurationChange:
+            reasonString = "unknown"
+        @unknown default:
+            reasonString = "unknown"
+        }
+        
+        sendEvent(deviceReconnectedEvent, ["reason": reasonString])
     }
     
     func onSoundChunkPlayed(_ isFinal: Bool) {

--- a/ios/SoundPlayer.swift
+++ b/ios/SoundPlayer.swift
@@ -58,6 +58,7 @@ class SoundPlayer {
             } catch {
                 Logger.debug("[SoundPlayer] Failed to setup audio engine: \(error.localizedDescription)")
             }
+            self.delegate?.onDeviceReconnected(reason)
         case .categoryChange:
             Logger.debug("[SoundPlayer] Audio Session category changed")
         default:

--- a/ios/SoundPlayerDelegate.swift
+++ b/ios/SoundPlayerDelegate.swift
@@ -1,4 +1,7 @@
+import AVFoundation
+
 protocol SoundPlayerDelegate: AnyObject {
-   func onSoundChunkPlayed(_ isFinal: Bool)
-   func onSoundStartedPlaying()
+    func onSoundChunkPlayed(_ isFinal: Bool)
+    func onSoundStartedPlaying()
+    func onDeviceReconnected(_ reason: AVAudioSession.RouteChangeReason)
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mykin-ai/expo-audio-stream",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Expo Play Audio Stream module",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/events.ts
+++ b/src/events.ts
@@ -28,10 +28,25 @@ export type SoundChunkPlayedEventPayload = {
     isFinal: boolean
 }
 
+export const DeviceReconnectedReasons = {
+    newDeviceAvailable: 'newDeviceAvailable',
+    oldDeviceUnavailable: 'oldDeviceUnavailable',
+    unknown: 'unknown',
+} as const
+
+export type DeviceReconnectedReason = {
+    reason: typeof DeviceReconnectedReasons[keyof typeof DeviceReconnectedReasons]
+}
+
+export type DeviceReconnectedEventPayload = {
+    reason: DeviceReconnectedReason
+}
+
 export const AudioEvents = {
     AudioData: 'AudioData',
     SoundChunkPlayed: 'SoundChunkPlayed',
     SoundStarted: 'SoundStarted',
+    DeviceReconnected: 'DeviceReconnected',
 }
 
 export function addAudioEventListener(

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ import {
   SoundChunkPlayedEventPayload,
   AudioEvents,
   subscribeToEvent,
+  DeviceReconnectedReason,
+  DeviceReconnectedEventPayload,
 } from "./events";
 
 const SuspendSoundEventTurnId = "suspend-sound-events";
@@ -407,11 +409,23 @@ export class ExpoPlayAudioStream {
   static promptMicrophoneModes() {
     ExpoPlayAudioStreamModule.promptMicrophoneModes();
   }
+
+  /**
+   * Toggles the silence state of the microphone.
+   * @returns {Promise<void>}
+   * @throws {Error} If the microphone fails to toggle silence.
+   */
+  static toggleSilence() {
+    ExpoPlayAudioStreamModule.toggleSilence();
+  }
+
 }
 
 export {
   AudioDataEvent,
   SoundChunkPlayedEventPayload,
+  DeviceReconnectedReason,
+  DeviceReconnectedEventPayload,
   AudioRecording,
   RecordingConfig,
   StartRecordingResult,


### PR DESCRIPTION
- Added `toggleSilence` function to mute microphone by sending silence back
- Added routeChange handler for Microphone to handle device reconnect to stop/start recording for new input
- Bubble up device reconnect event to RN for better control