### PR TITLE
Set the AVAudioSession to inactive when destroying the audio resources.

### DIFF
--- a/ios/ExpoPlayAudioStreamModule.swift
+++ b/ios/ExpoPlayAudioStreamModule.swift
@@ -50,7 +50,11 @@ public class ExpoPlayAudioStreamModule: Module, AudioStreamManagerDelegate, Micr
             self._audioSessionManager = nil
             self._microphone = nil
             self._soundPlayer = nil
-            self.isAudioSessionInitialized = false
+            if self.isAudioSessionInitialized {
+                let audioSession = AVAudioSession.sharedInstance()
+                try audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+                self.isAudioSessionInitialized = false
+            }
         }
         
         /// Prompts the user to select the microphone mode.


### PR DESCRIPTION
This frees up the lock on the microphone hardware (Removes orange dot showing mic in use)