### PR TITLE
Allow explicit silence state to be passed in to toggleSilence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ These methods are specifically designed for scenarios where you need to record a
 
 - `playWav(wavBase64: string)`: Plays a WAV format audio file from base64 encoded data. Unlike playSound(), this method plays the audio directly without queueing. The audio data should be base64 encoded WAV format. Throws an error if the WAV audio fails to play.
 
-- `toggleSilence()`: Toggles the silence state of the microphone during recording. This can be useful for temporarily muting the microphone without stopping the recording session. Throws an error if the microphone fails to toggle silence.
+- `toggleSilence(isSilent?: boolean)`: Sets or toggles the silence state of the microphone during recording. This can be useful for temporarily muting the microphone without stopping the recording session. Throws an error if the microphone fails to toggle silence.  Passing undefined will toggle the current value.
 
 - `promptMicrophoneModes()`: Prompts the user to select the microphone mode (iOS specific feature).
 

--- a/android/src/main/java/expo/modules/audiostream/AudioRecorderManager.kt
+++ b/android/src/main/java/expo/modules/audiostream/AudioRecorderManager.kt
@@ -467,8 +467,8 @@ class AudioRecorderManager(
     /**
      * Toggles between sending actual audio data and silence
      */
-    fun toggleSilence() {
-        isSilent = !isSilent
+    fun toggleSilence(isSilent: Boolean?) {
+        this.isSilent = isSilent ?: !this.isSilent
         Log.d(Constants.TAG, "Silence mode toggled: $isSilent")
     }
 

--- a/android/src/main/java/expo/modules/audiostream/ExpoPlayAudioStreamModule.kt
+++ b/android/src/main/java/expo/modules/audiostream/ExpoPlayAudioStreamModule.kt
@@ -228,9 +228,9 @@ class ExpoPlayAudioStreamModule : Module(), EventSender {
             audioRecorderManager.stopRecording(promise)
         }
 
-        Function("toggleSilence") {
+        Function("toggleSilence") { isSilent: Boolean? ->
             // Just toggle silence without returning any value
-            audioRecorderManager.toggleSilence()
+            audioRecorderManager.toggleSilence(isSilent)
         }
 
         AsyncFunction("setSoundConfig") { config: Map<String, Any?>, promise: Promise ->

--- a/ios/ExpoPlayAudioStreamModule.swift
+++ b/ios/ExpoPlayAudioStreamModule.swift
@@ -328,8 +328,8 @@ public class ExpoPlayAudioStreamModule: Module, AudioStreamManagerDelegate, Micr
             microphone.stopRecording(resolver: promise)
         }
         
-        Function("toggleSilence") {
-            microphone.toggleSilence()
+        Function("toggleSilence") { (isSilent: Bool?) in
+            microphone.toggleSilence(isSilent: isSilent)
         }
         
         /// Sets the sound player configuration

--- a/ios/Microphone.swift
+++ b/ios/Microphone.swift
@@ -67,9 +67,9 @@ class Microphone {
         }
     }
     
-    func toggleSilence() {
+    func toggleSilence(isSilent: Bool?) {
         Logger.debug("[Microphone] toggleSilence")
-        self.isSilent = !self.isSilent
+        self.isSilent = isSilent ?? !self.isSilent
     }
     
     func startRecording(settings: RecordingSettings, intervalMilliseconds: Int) -> StartRecordingResult? {
@@ -198,7 +198,7 @@ class Microphone {
             finalBuffer = buffer
         }
         
-        let powerLevel: Float = AudioUtils.calculatePowerLevel(from: finalBuffer)
+        let powerLevel: Float = isSilent ? -160.0 : AudioUtils.calculatePowerLevel(from: finalBuffer)
         
         let audioData = finalBuffer.audioBufferList.pointee.mBuffers
         guard let bufferData = audioData.mData else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -589,8 +589,8 @@ export class ExpoPlayAudioStream {
    * @returns {Promise<void>}
    * @throws {Error} If the microphone fails to toggle silence.
    */
-  static toggleSilence() {
-    ExpoPlayAudioStreamModule.toggleSilence();
+  static toggleSilence(isSilent?: boolean | null) {
+    ExpoPlayAudioStreamModule.toggleSilence(isSilent ?? null);
   }
 
   /**


### PR DESCRIPTION
This removes the guesswork for the JS side to know what the current silence state is.

I also noticed android sets the power level to -160 when silenced, but iOS did not. This aligns the two.