### PR TITLE
Allow the max frame size to be configurable.

### DIFF
--- a/src/audio/BufferManagerCore.ts
+++ b/src/audio/BufferManagerCore.ts
@@ -34,11 +34,13 @@ export class AudioBufferManager
       minBufferMs: 120,
       maxBufferMs: 480,
       frameIntervalMs: 20,
+      frameMaxSizeBytes: 64 * 1024,
       ...config,
     };
 
     this._frameProcessor = new FrameProcessor(
-      this._config.frameIntervalMs
+      this._config.frameIntervalMs,
+      this._config.frameMaxSizeBytes
     );
     this._qualityMonitor = new QualityMonitor(
       this._config.frameIntervalMs

--- a/src/audio/FrameProcessor.ts
+++ b/src/audio/FrameProcessor.ts
@@ -11,16 +11,21 @@ import {
 export class FrameProcessor implements IFrameProcessor {
   private static readonly _sampleRate = 16000; // 16kHz
   private static readonly _bytesPerSample = 2; // 16-bit PCM
-  private static readonly _maxReasonableChunkSizeBytes =
+  private static readonly _defaultMaxReasonableChunkSizeBytes =
     64 * 1024; // 64KB safety
   private static readonly _validBase64Regex =
     /^[A-Za-z0-9+/]*={0,2}$/;
 
   private _sequenceNumber: number = 0;
   private _frameIntervalMs: number;
+  private _maxReasonableChunkSizeBytes: number
 
-  constructor(frameIntervalMs: number = 20) {
+  constructor(
+    frameIntervalMs: number = 20, 
+    maxChunkSizeBytes: number = FrameProcessor._defaultMaxReasonableChunkSizeBytes
+  ) {
     this._frameIntervalMs = frameIntervalMs;
+    this._maxReasonableChunkSizeBytes = maxChunkSizeBytes
   }
 
   /** Parse an audio payload into timestamped frames with validation. */
@@ -89,8 +94,9 @@ export class FrameProcessor implements IFrameProcessor {
     const estimatedDecodedSize =
       (payload.audioData.length * 3) / 4;
     if (
+      this._maxReasonableChunkSizeBytes > 0 &&
       estimatedDecodedSize >
-      FrameProcessor._maxReasonableChunkSizeBytes
+      this._maxReasonableChunkSizeBytes
     ) {
       console.warn(
         'FrameProcessor: Chunk size exceeds reasonable limit:',

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,6 +186,7 @@ export interface IAudioBufferConfig {
   minBufferMs: number; // Minimum buffer size before underrun handling
   maxBufferMs: number; // Maximum buffer size before overrun handling
   frameIntervalMs: number; // Expected frame interval in milliseconds
+  frameMaxSizeBytes: number; // Maximum expected size of each audio frame in bytes
 }
 
 /**


### PR DESCRIPTION
The XAI realtime voice agent sends back chunks larger than the 64kb default limit.